### PR TITLE
String and Char Literal Tokenization

### DIFF
--- a/neo-lib/src/neo.zig
+++ b/neo-lib/src/neo.zig
@@ -62,15 +62,17 @@ usingnamespace if (builtin.target.isWasm()) struct {
         };
     }
 
+    const Tokens = extern struct {
+        ptr: [*]u16,
+        len: usize,
+    };
+
     // TODO: Handle C Pointers.
-    export fn Neo_Tokenize(source_ptr: [*]const u8, source_len: usize) callconv(.C) Slice {
+    export fn Neo_Tokenize(source_ptr: [*]const u8, source_len: usize) callconv(.C) Tokens {
         const source = tokenizer.Source.fromRawBuffer(source_ptr, source_len);
         const tokens = tokenizer.tokenize(allocator, source) catch unreachable;
 
-        return .{
-            .ptr = tokens.ptr,
-            .len = tokens.len,
-        };
+        return .{ .ptr = @alignCast(@ptrCast(tokens.ptr)), .len = tokens.len };
     }
 
     export fn Neo_Token_Name(tag: tokenizer.Token.Tag) callconv(.C) [*:0]const u8 {

--- a/neo-lib/src/tokenizer.zig
+++ b/neo-lib/src/tokenizer.zig
@@ -10,6 +10,7 @@ const Tokenizer = struct {
         start,
         ident,
         symbol,
+        eof,
     };
 
     text: [:0]const u8,
@@ -28,46 +29,53 @@ const Tokenizer = struct {
 
         state: switch (State.start) {
             .start => switch (self.text[self.begin]) {
-                '(', ')', '{', '}', '[', ']', '.', ':', ',', '?', '+', '-', '*', '/', '%', '^', '&', '|', '!', '=', '<', '>', '~' => {
+                '.', ':', ',', '?', '+', '-', '*', '/', '%', '^', '&', '|', '!', '=', '<', '>', '~' => {
                     self.index = self.begin;
                     continue :state .symbol;
                 },
+                '(', ')', '{', '}', '[', ']' => {
+                    const slice = self.text[self.begin..][0..1];
+                    const symbol = Symbols.lookup(slice).?;
+
+                    self.index += 1;
+                    self.push(symbol);
+                    self.begin += 1;
+
+                    continue :state .start;
+                },
                 'A'...'Z', 'a'...'z', '_' => {
-                    self.index = self.begin;
+                    self.index = self.begin + 1;
                     continue :state .ident;
                 },
                 '\t', '\r', ' ' => {
-                    self.index = self.begin;
+                    self.index = self.begin + 1;
                     continue :state .whitespace;
                 },
                 '0'...'9' => {
-                    self.index = self.begin;
+                    self.index = self.begin + 1;
                     continue :state .number;
                 },
                 '\n' => {
-                    self.index = self.begin;
+                    self.index = self.begin + 1;
                     continue :state .newline;
                 },
                 '\"' => {
-                    self.index = self.begin;
+                    self.index = self.begin + 1;
                     continue :state .string;
                 },
                 '\'' => {
-                    self.index = self.begin;
+                    self.index = self.begin + 1;
                     continue :state .char;
-                },
-                0 => {
-                    // TODO: Handle invalid eof.
-                    self.push(.eof);
-                    break :state;
                 },
                 else => {
                     // TODO: Handle
                     self.push(.invalid);
+                    continue :state .eof;
                 },
+                0 => continue :state .eof,
             },
             .symbol => switch (self.text[self.index]) {
-                '(', ')', '{', '}', '[', ']', '.', ':', ',', '?', '+', '-', '*', '/', '%', '^', '&', '|', '!', '=', '<', '>', '~' => {
+                '.', ':', ',', '?', '+', '-', '*', '/', '%', '^', '&', '|', '!', '=', '<', '>', '~' => {
                     self.index += 1;
                     continue :state .symbol;
                 },
@@ -120,8 +128,16 @@ const Tokenizer = struct {
             .string => switch (self.text[self.index]) {
                 // TODO: Handle escaping. Ugh.
                 '\"' => {
+                    self.index += 1;
                     self.pushAndReset(.string);
                     continue :state .start;
+                },
+                0 => {
+                    // TODO: We need to denote that invalid tokens that take up the entire buffer have a len of 0.
+                    self.tokens[self.tokenCount] = .{ .tag = .invalid, .len = 0 };
+                    self.tokenCount += 1;
+
+                    continue :state .eof;
                 },
                 else => {
                     self.index += 1;
@@ -133,13 +149,26 @@ const Tokenizer = struct {
                 '\'' => {
                     const tag: Token.Tag = if (self.index - self.begin > 2) .invalid else .char;
 
+                    self.index += 1;
                     self.pushAndReset(tag);
                     continue :state .start;
                 },
+                0 => {
+                    // TODO: We need to denote that invalid tokens that take up the entire buffer have a len of 0.
+                    self.tokens[self.tokenCount] = .{ .tag = .invalid, .len = 0 };
+                    self.tokenCount += 1;
+
+                    continue :state .eof;
+                },
                 else => {
                     self.index += 1;
-                    continue :state .string;
+                    continue :state .char;
                 },
+            },
+            .eof => {
+                // TODO: Handle invalid eof.
+                self.tokens[self.tokenCount] = .{ .tag = .eof, .len = 0 };
+                break :state;
             },
         }
 
@@ -213,14 +242,72 @@ test "tokenize" {
     try std.testing.expectEqualSlices(Token, tokens, &expected_tokens);
 }
 
+test "tokenize groupings" {
+    const text = "()";
+
+    const source = try Source.fromText(std.testing.allocator, text);
+    defer source.deinit(std.testing.allocator);
+
+    const tokens = try Tokenizer.tokenize(std.testing.allocator, source);
+    defer std.testing.allocator.free(tokens);
+
+    const expected_tokens = [_]Token{
+        .{ .tag = .@"(", .len = 1 },
+        .{ .tag = .@")", .len = 1 },
+        .{ .tag = .newline, .len = 1 },
+        .{ .tag = .eof, .len = 0 },
+    };
+
+    try std.testing.expectEqualSlices(Token, tokens, &expected_tokens);
+}
+
 test "tokenize strings" {
-    try std.testing.expect(false);
+    const text = (
+        \\ "hello" "world"
+    );
+
+    const source = try Source.fromText(std.testing.allocator, text);
+    defer source.deinit(std.testing.allocator);
+
+    const tokens = try Tokenizer.tokenize(std.testing.allocator, source);
+    defer std.testing.allocator.free(tokens);
+
+    const expected_tokens = [_]Token{
+        .{ .tag = .whitespace, .len = 1 },
+        .{ .tag = .string, .len = 7 },
+        .{ .tag = .whitespace, .len = 1 },
+        .{ .tag = .string, .len = 7 },
+        .{ .tag = .newline, .len = 1 },
+        .{ .tag = .eof, .len = 0 },
+    };
+
+    try std.testing.expectEqualSlices(Token, tokens, &expected_tokens);
 }
 
 test "tokenize chars" {
+    const text = (
+        \\ 'a' '1' '*'
+    );
 
+    const source = try Source.fromText(std.testing.allocator, text);
+    defer source.deinit(std.testing.allocator);
+
+    const tokens = try Tokenizer.tokenize(std.testing.allocator, source);
+    defer std.testing.allocator.free(tokens);
+
+    const expected_tokens = [_]Token{
+        .{ .tag = .whitespace, .len = 1 },
+        .{ .tag = .char, .len = 3 },
+        .{ .tag = .whitespace, .len = 1 },
+        .{ .tag = .char, .len = 3 },
+        .{ .tag = .whitespace, .len = 1 },
+        .{ .tag = .char, .len = 3 },
+        .{ .tag = .newline, .len = 1 },
+        .{ .tag = .eof, .len = 0 },
+    };
+
+    try std.testing.expectEqualSlices(Token, tokens, &expected_tokens);
 }
-
 pub const tokenize = Tokenizer.tokenize;
 
 pub const Token = @import("tokenizer/Token.zig");

--- a/neo-lib/src/tokenizer.zig
+++ b/neo-lib/src/tokenizer.zig
@@ -4,6 +4,8 @@ const Tokenizer = struct {
     const State = enum {
         whitespace,
         newline,
+        string,
+        char,
         number,
         start,
         ident,
@@ -15,8 +17,8 @@ const Tokenizer = struct {
     tokens: []Token = undefined,
     tokenCount: usize = 0,
 
-    begin: usize = 0,
-    index: usize = 0,
+    begin: u32 = 0,
+    index: u32 = 0,
 
     pub fn tokenize(allocator: std.mem.Allocator, source: Source) ![]Token {
         var self = Tokenizer{ .text = source.text() };
@@ -45,6 +47,14 @@ const Tokenizer = struct {
                 '\n' => {
                     self.index = self.begin;
                     continue :state .newline;
+                },
+                '\"' => {
+                    self.index = self.begin;
+                    continue :state .string;
+                },
+                '\'' => {
+                    self.index = self.begin;
+                    continue :state .char;
                 },
                 0 => {
                     // TODO: Handle invalid eof.
@@ -107,6 +117,30 @@ const Tokenizer = struct {
                     continue :state .start;
                 },
             },
+            .string => switch (self.text[self.index]) {
+                // TODO: Handle escaping. Ugh.
+                '\"' => {
+                    self.pushAndReset(.string);
+                    continue :state .start;
+                },
+                else => {
+                    self.index += 1;
+                    continue :state .string;
+                },
+            },
+            .char => switch (self.text[self.index]) {
+                // TODO: Handle escaping. Ugh.
+                '\'' => {
+                    const tag: Token.Tag = if (self.index - self.begin > 2) .invalid else .char;
+
+                    self.pushAndReset(tag);
+                    continue :state .start;
+                },
+                else => {
+                    self.index += 1;
+                    continue :state .string;
+                },
+            },
         }
 
         return self.shrink(allocator);
@@ -138,6 +172,7 @@ const Tokenizer = struct {
         // TODO: Handle non-resizable allocator like wasm better.
         // The issue being, we don't want to return a slice that points past the valid tokens.
         // We also don't want to return a slice that won't allow us to free the allocated memory if resize fails.
+        // The current behavior is to have the consumer of the tokenizer buffer remember to check for the ending eof. I do not like this.
         return self.tokens[0..if (allocator.resize(self.tokens, self.tokenCount)) self.tokenCount else self.tokens.len];
     }
 };
@@ -176,6 +211,14 @@ test "tokenize" {
     };
 
     try std.testing.expectEqualSlices(Token, tokens, &expected_tokens);
+}
+
+test "tokenize strings" {
+    try std.testing.expect(false);
+}
+
+test "tokenize chars" {
+
 }
 
 pub const tokenize = Tokenizer.tokenize;

--- a/neo-lib/src/tokenizer/Source.zig
+++ b/neo-lib/src/tokenizer/Source.zig
@@ -70,7 +70,7 @@ pub fn text(self: *const Source) [:0]const u8 {
 }
 
 pub fn estimatedTokenSize(self: *const Source) usize {
-    return self.buffer.len;
+    return self.buffer.len + 3;
 }
 
 pub fn deinit(self: *const Source, allocator: std.mem.Allocator) void {

--- a/neo-lib/src/tokenizer/Source.zig
+++ b/neo-lib/src/tokenizer/Source.zig
@@ -1,3 +1,6 @@
+// TODO: Error handling when source size greater than std.math.maxInt(u32).
+// Why would you ever need to compile 4 gigs of source code at once???
+
 const std = @import("std");
 
 const Source = @This();

--- a/neo-lib/src/tokenizer/Token.zig
+++ b/neo-lib/src/tokenizer/Token.zig
@@ -9,8 +9,7 @@ comptime {
     std.debug.assert(@sizeOf(Token) == 2);
     std.debug.assert(@offsetOf(Token, "tag") == 0);
     std.debug.assert(@offsetOf(Token, "len") == 1);
-    @compileLog(@alignOf(Token));
-    @compileLog(@alignOf([*]Token));
+    // TODO: Alignment assertions because of ABI stuff. Ugh.
 }
 
 tag: Tag,

--- a/neo-lib/src/tokenizer/Token.zig
+++ b/neo-lib/src/tokenizer/Token.zig
@@ -9,6 +9,8 @@ comptime {
     std.debug.assert(@sizeOf(Token) == 2);
     std.debug.assert(@offsetOf(Token, "tag") == 0);
     std.debug.assert(@offsetOf(Token, "len") == 1);
+    @compileLog(@alignOf(Token));
+    @compileLog(@alignOf([*]Token));
 }
 
 tag: Tag,


### PR DESCRIPTION
Features:

- Updated the tokenizer to tokenize unescaped string and char literals.
  -  "abcdef" ✅
  - "\n\t" ❌

Bugfixes: 
- Fixed a bug where if the last token is invalid, a eof token does not get added leading to weird behavior in the explorer.
- Fixed a bug where grouping symbols like '(' and ')' would not get tokenized if no whitespace is present '()'. They now tokenize as expected.